### PR TITLE
__defineSetter__ is deprecated.

### DIFF
--- a/iugo-core.js
+++ b/iugo-core.js
@@ -51,19 +51,21 @@ $iugo.$internals.applySetters = function(obj, mvvc, props, modelMember) {
  */
 $iugo.$internals.registerProperty = function(obj, field, mvvc, path) {
 	mvvc.$[path.concat([field]).join('.')] = obj[field];
-	obj.__defineSetter__(field, function(value) {
-		mvvc.$[path.concat([field]).join('.')] = value;
-		// Recurse children and set them too
-		$iugo.$internals.setChildMembers(obj, mvvc, path);
-		
-		// as the setter is already defined we can just update the view
-		// as opposed to pushing to an array where a reset of the model member is required
-		// NB. if this were a full update (mvvc[path[0]] = mvvc[path[0]]) an infinite loop would be generated when pushing to an array
-		mvvc.updateView(path[0], mvvc[path[0]]);
-	})
-	obj.__defineGetter__(field, function() {
-		return mvvc.$[path.concat([field]).join('.')];
-	})
+	Object.defineProperty(obj, field, {
+        get: function() {
+            return mvvc.$[path.concat([field]).join('.')];
+        },
+        set: function(value) {
+            mvvc.$[path.concat([field]).join('.')] = value;
+            // Recurse children and set them too
+            $iugo.$internals.setChildMembers(obj, mvvc, path);
+            
+            // as the setter is already defined we can just update the view
+            // as opposed to pushing to an array where a reset of the model member is required
+            // NB. if this were a full update (mvvc[path[0]] = mvvc[path[0]]) an infinite loop would be generated when pushing to an array
+            mvvc.updateView(path[0], mvvc[path[0]]);
+        }
+    })
 };
 /**
  *

--- a/iugo.js
+++ b/iugo.js
@@ -45,19 +45,21 @@ $iugo.$internals.applySetters = function(obj, mvvc, props, modelMember) {
  */
 $iugo.$internals.registerProperty = function(obj, field, mvvc, path) {
 	mvvc.$[path.concat([field]).join('.')] = obj[field];
-	obj.__defineSetter__(field, function(value) {
-		mvvc.$[path.concat([field]).join('.')] = value;
-		// Recurse children and set them too
-		$iugo.$internals.setChildMembers(obj, mvvc, path);
-		
-		// as the setter is already defined we can just update the view
-		// as opposed to pushing to an array where a reset of the model member is required
-		// NB. if this were a full update (mvvc[path[0]] = mvvc[path[0]]) an infinite loop would be generated when pushing to an array
-		mvvc.updateView(path[0], mvvc[path[0]]);
-	})
-	obj.__defineGetter__(field, function() {
-		return mvvc.$[path.concat([field]).join('.')];
-	})
+	Object.defineProperty(obj, field, {
+        get: function() {
+            return mvvc.$[path.concat([field]).join('.')];
+        },
+        set: function(value) {
+            mvvc.$[path.concat([field]).join('.')] = value;
+            // Recurse children and set them too
+            $iugo.$internals.setChildMembers(obj, mvvc, path);
+            
+            // as the setter is already defined we can just update the view
+            // as opposed to pushing to an array where a reset of the model member is required
+            // NB. if this were a full update (mvvc[path[0]] = mvvc[path[0]]) an infinite loop would be generated when pushing to an array
+            mvvc.updateView(path[0], mvvc[path[0]]);
+        }
+    })
 };
 /**
  *


### PR DESCRIPTION
In IE10 - and possibly older, untested - Iugo throws "Object doesn't
support property or method '**defineSetter**' when in use" when in use
and when running the tests.

This changes it to use Object.defineProperty instead.

I haven't regenerated the minified files as I don't know what minifier you're using, just so you're aware :-)

Tests were run in IE10 on Windows, Opera 12.15 on Linux, Firefox 21 on Linux, Chrome 26 on Linux.

Cheers :-)
